### PR TITLE
Adding POST method with disparate return type

### DIFF
--- a/Simple.Rest/IRestClient.cs
+++ b/Simple.Rest/IRestClient.cs
@@ -44,7 +44,7 @@ namespace Simple.Rest
         /// <param name="url">The URL to GET the resource</param>
         /// <returns>Returns the resource wrapped in a Task&lt;IRestResponse&lt;T&gt;&gt;, the interface contains the resource, status code &amp; description, headers &amp; cookies.</returns>
         Task<IRestResponse<T>> GetAsync<T>(Uri url) where T : class;
-
+        
         /// <summary>
         /// Requests the resource be stored under the supplied URL asynchronuously. If the URL refers to an already existing resource, it is modified.
         /// If the URL does not point to an existing resource, then the server can create the resource with that URL.
@@ -65,10 +65,22 @@ namespace Simple.Rest
         Task<IRestResponse<T>> PostAsync<T>(Uri url, T resource) where T : class;
 
         /// <summary>
-        /// Deletes a resource asynchronously. The resource is identified by the URL.
-        /// </summary>
-        /// <param name="url">The URL to GET the resource</param>
-        /// <returns>Returns the result in a Task&lt;IRestResponse&gt;, the interface contains the status code &amp; description, headers &amp; cookies.</returns>
-        Task<IRestResponse> DeleteAsync(Uri url);
+				/// Requests the server accept the resource asynchronuously and receives a disparate return type. The resource is identified by the URL.
+				/// </summary>
+				/// <typeparam name="T">The resource type</typeparam>
+				/// <typeparam name="R">The return type</typeparam>
+				/// <param name="url">The URL to POST the resource</param>
+				/// <param name="resource">The resource to be POST'd</param>
+				/// <returns>Returns the return type wrapped in a Task&lt;IRestResponse&lt;&gt;&gt;, the interface contains the return, status code &amp; description, headers &amp; cookies.</returns>
+        Task<IRestResponse<R>> PostAsync<T, R>(Uri url, T resource)
+						where T : class
+						where R : class;
+
+				/// <summary>
+				/// Deletes a resource asynchronously. The resource is identified by the URL.
+				/// </summary>
+				/// <param name="url">The URL to GET the resource</param>
+				/// <returns>Returns the result in a Task&lt;IRestResponse&gt;, the interface contains the status code &amp; description, headers &amp; cookies.</returns>
+				Task<IRestResponse> DeleteAsync(Uri url);
     }
 }

--- a/Simple.Rest/RestClient.cs
+++ b/Simple.Rest/RestClient.cs
@@ -116,6 +116,22 @@
         }
 
         /// <summary>
+				/// Requests the server accept the resource asynchronuously and receives a disparate return type. The resource is identified by the URL.
+				/// </summary>
+				/// <typeparam name="T">The resource type</typeparam>
+				/// <typeparam name="R">The return type</typeparam>
+				/// <param name="url">The URL to POST the resource</param>
+				/// <param name="resource">The resource to be POST'd</param>
+				/// <returns>Returns the return type wrapped in a Task&lt;IRestResponse&lt;&gt;&gt;, the interface contains the return, status code &amp; description, headers &amp; cookies.</returns>
+				[Pure]
+        public Task<IRestResponse<R>> PostAsync<T, R>(Uri url, T resource)
+						where T : class
+						where R : class
+        {
+            return ExecuteRequest<T, R>(url, HttpMethod.Post, resource);
+        }
+
+        /// <summary>
         /// Deletes a resource asynchronously. The resource is identified by the URL.
         /// </summary>
         /// <param name="url">The URL to GET the resource</param>

--- a/Simple.Rest/RestClientContract.cs
+++ b/Simple.Rest/RestClientContract.cs
@@ -42,6 +42,16 @@ namespace Simple.Rest
             return null;
         }
 
+        public Task<IRestResponse<R>> PostAsync<T, R>(Uri url, T resource)
+						where T : class
+						where R : class
+        {
+            Contract.Requires<ArgumentNullException>(url != null);
+            Contract.Requires<ArgumentNullException>(resource != null);
+
+            return null;
+        }
+
         public Task<IRestResponse> DeleteAsync(Uri url)
         {
             Contract.Requires<ArgumentNullException>(url != null);


### PR DESCRIPTION
Needed the ability to submit a request that has a return type different from the resource type.  Already supported by RestClient.ExecuteRequest<TRequest, TResponse>(), just added the interface method.